### PR TITLE
Feat: Add animations for button presses and network list

### DIFF
--- a/themes.py
+++ b/themes.py
@@ -131,7 +131,10 @@ def apply_theme_to_widget(widget, theme_colors: dict):
     if widget_type == "Button":
         widget.config(
             bg=theme_colors.get("btn_bg"),
-            activebackground=theme_colors.get("btn_active_bg")
+            fg=theme_colors.get("fg_color"), # Ensure fg is also set
+            activebackground=theme_colors.get("btn_active_bg"),
+            activeforeground=theme_colors.get("fg_color"), # Ensure active fg is also set
+            relief=tk.RAISED # Default relief for buttons
         )
     elif widget_type == "Entry":
         widget.config(


### PR DESCRIPTION
- Implemented press/release animations for major buttons (Scan, Load Dictionary, Start).
  - On press, buttons change relief to SUNKEN and use the theme's active background color.
  - On release, buttons revert to their standard themed appearance.
- Added a cascading fade-in animation for items appearing in the network list after a scan.
  - Items are initially rendered 'invisibly' and then their colors are updated via staggered `after` calls.
- Ensured animations are theme-aware and update correctly if the theme is changed during an animation or interaction.
- Updated `themes.py` to include default relief for buttons to support animation states.